### PR TITLE
Implemented workaround for tick labels being reformated.

### DIFF
--- a/better_graphs/better_graphs.py
+++ b/better_graphs/better_graphs.py
@@ -112,6 +112,26 @@ def beautify_bars_h(ax, index, rounding=2, factor=0.1, num_bars_per_group=1):
         ax.spines['top'].set_visible(False)
 
 
+def _tick_label_workaround(ticks):
+    """
+    Correctly formats tick labels to be integers or floats depending on the tick value
+    :param ticks:
+    :return:
+    """
+    tick_labels = ticks
+    all_ints = True
+
+    for tick in ticks:
+        if np.abs(tick - int(tick)) > 0:
+            all_ints = False
+            break
+
+    if all_ints:
+        tick_labels = [str(int(tick)) for tick in ticks]
+
+    return tick_labels
+
+
 def add_custom_ticks(ax, new_locs, new_labels, which='x'):
     """
     Add custom ticks to plot axes `ax` on either the x or y axis at location `newLocs` with tick labels `newLabels`.
@@ -136,14 +156,19 @@ def add_custom_ticks(ax, new_locs, new_labels, which='x'):
         ticks = ax.get_xticks()
         # hack that fixes a weird bug in mpl where a float will not be rounded correctly, causing havoc
         ticks = [np.round(tick, 9) for tick in ticks]
-        ax.set_xticklabels(ticks)  # "Set" ticks must be done to access text
+        tick_labels = _tick_label_workaround(ticks)
+
+        ax.set_xticklabels(tick_labels)  # "Set" ticks must be done to access text
+        print(ax.get_xticklabels()[:])
         labels = ax.get_xticklabels()
         labels = [t.get_text() for t in labels]  # Extract text from labels
 
     elif which == 'y':
         ticks = ax.get_yticks()
         ticks = [np.round(tick, 9) for tick in ticks]  # Same hack as used for xticks above
-        ax.set_yticklabels(ticks)
+        tick_labels = _tick_label_workaround(ticks)
+
+        ax.set_yticklabels(tick_labels)
         labels = ax.get_yticklabels()
         labels = [t.get_text() for t in labels]
 

--- a/better_graphs/defaults.py
+++ b/better_graphs/defaults.py
@@ -19,9 +19,9 @@ def set_pretty_defaults(palette='Set1', context='paper', font_scale=2, line_widt
         Line width to use when drawing plots.
     """
     
-    tex_font = 'cm'
-    if 'tex_font' in kwargs:
-        tex_font = kwargs['tex_font']
+    font = 'CMU Serif'
+    if 'font' in kwargs:
+        font = kwargs['font']
 
     # Set Seaborn template
     sns.set_style('ticks')
@@ -39,6 +39,6 @@ def set_pretty_defaults(palette='Set1', context='paper', font_scale=2, line_widt
     # Enable LaTeX font rendering
     if tex:
         plt.rc('text', usetex=True)
-        plt.rc('font', serif=tex_font)
+        plt.rc('font', serif=font)
         plt.rc('font', family='serif')
         plt.rc('text.latex', preamble=r'\usepackage{amsmath}')


### PR DESCRIPTION
This was a result of matplotlib not making tick labels
available *before* a plot is drawn. The solution is to
set the tick labels to the ticks. The problem with this
approach is that since the ticks are floats, that if
they're whole numbers, they will be displayed with
a trailing zero when adding custom ticks.

Workaround is to handle this parsing ourself, rather
than let matplotlib try to guess what we're doing.